### PR TITLE
update homebrew howto

### DIFF
--- a/building.rst
+++ b/building.rst
@@ -139,7 +139,7 @@ Homebrew_, then do the following:
 
     brew install homebrew-gui/hexchat --with-python
     # or to build directly from git:
-    # brew install homebrew-gui/hexchat --HEAD --with-python
+    # brew install homebrew-gui/hexchat --HEAD --with-python --without-plugins
 
     # then launch it
     /usr/local/bin/hexchat

--- a/building.rst
+++ b/building.rst
@@ -137,9 +137,9 @@ Homebrew_, then do the following:
 
 .. code-block:: bash
 
-    brew install hexchat --with-python
+    brew install homebrew-gui/hexchat --with-python
     # or to build directly from git:
-    # brew install --HEAD hexchat --with-python
+    # brew install homebrew-gui/hexchat --HEAD --with-python
 
     # then launch it
     /usr/local/bin/hexchat


### PR DESCRIPTION
Some changes in the location of the published homebrew formula and in hexchat dependencies on OSX necessitate minor updates to associated documentation.