### PR TITLE
Add missing :command: markup to the exec addon

### DIFF
--- a/addons.rst
+++ b/addons.rst
@@ -11,7 +11,7 @@ A list of many existing addons can be found at `https://github.com/hexchat/hexch
 Exec
 ----
 
-The exec plugin provides the /exec command for Windows, it is built in on Unix.
+The exec plugin provides the :command:`/exec` command for Windows, it is built in on Unix.
 
 With Exec you can perform commands as if you ran them in the command line. The output will be printed at once, in the end of execution. If the command takes more than 10 seconds to complete, it gets aborted to avoid locking down HexChat. Usage:
 


### PR DESCRIPTION
I figured the `:command:` markup might have been intended to be used here to be consistent with the rest of the addons document.