### PR TITLE
Meson Build Option: Theme Manager

### DIFF
--- a/building.rst
+++ b/building.rst
@@ -115,7 +115,7 @@ The theme manager isn't built by default on Unix. To do so get hexchat's source 
 
 .. code-block:: bash
 
-    meson configure build -Dwith-theme-manager=true
+    meson configure build -Dtheme-manager=true
     ninja -C build
     sudo ninja -C build install
 


### PR DESCRIPTION
Update the docs with the correct meson option to build HexChat's theme
manager alongside HexChat ('with-theme-manager' -> 'theme-manager').  As
per meson options:
https://github.com/hexchat/hexchat/blob/7cff05c7ac4efe30a34f7f1bc5d5aa7463cb4f16/meson_options.txt#L8.